### PR TITLE
Upgrade Typescript to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "ts-transformer-strip-const-enums",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A TypeScript custom transformer which strips const enums if preserveConstEnums is enabled and const enum isn't exported",
   "main": "dist/transformer.js",
   "repository": {
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/timocov/ts-transformer-strip-const-enums",
   "peerDependencies": {
-    "typescript": ">=3.0.0"
+    "typescript": ">=5.0.0"
   },
   "devDependencies": {
     "@types/chai": "~4.2.11",
@@ -38,7 +38,7 @@
     "rimraf": "~3.0.2",
     "ts-node": "~8.10.1",
     "tslint": "~6.1.2",
-    "typescript": "~3.8.3"
+    "typescript": "~5.4.5"
   },
   "scripts": {
     "clean": "rimraf lib/ dist/",

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "typescript": ">=5.0.0"
   },
   "devDependencies": {
-    "@types/chai": "~4.2.11",
-    "@types/mocha": "~7.0.2",
-    "@types/node": "~13.13.4",
-    "chai": "~4.2.0",
-    "mocha": "~7.1.2",
+    "@types/chai": "~4.3.16",
+    "@types/mocha": "~10.0.6",
+    "@types/node": "~20.12.12",
+    "chai": "~5.1.1",
+    "mocha": "~10.4.0",
     "npm-run-all": "~4.1.5",
-    "rimraf": "~3.0.2",
-    "ts-node": "~8.10.1",
+    "rimraf": "~5.0.7",
+    "ts-node": "~10.9.2",
     "tslint": "~6.1.2",
     "typescript": "~5.4.5"
   },

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -69,8 +69,8 @@ function createTransformerFactory(program: ts.Program, options?: Partial<Options
 		return result.map((symbol: ts.Symbol) => getActualSymbol(symbol));
 	}
 
-	function hasModifier(node: ts.Node, modifier: ts.SyntaxKind): boolean {
-		return node.modifiers !== undefined && node.modifiers.some((mod: ts.Modifier) => mod.kind === modifier);
+	function hasModifier(node: ts.EnumDeclaration, modifier: ts.SyntaxKind): boolean {
+		return node.modifiers !== undefined && node.modifiers.some((mod: ts.ModifierLike) => mod.kind === modifier);
 	}
 
 	if (!compilerOptions.preserveConstEnums) {
@@ -112,7 +112,7 @@ function createTransformerFactory(program: ts.Program, options?: Partial<Options
 			const isExportedFromSourceFile = getExportsForSourceFile(node.getSourceFile()).includes(enumSymbol);
 			const isExportedFromEntries = fullOptions.entrySourceFiles.length === 0 || allExports.has(enumSymbol);
 			if (!isExportedFromSourceFile || !isExportedFromEntries) {
-				return ts.createEmptyStatement();
+				return ts.factory.createEmptyStatement();
 			}
 
 			return node;

--- a/tests/test-cases/simple/output.js
+++ b/tests/test-cases/simple/output.js
@@ -1,10 +1,11 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.doSomething = exports.ExportedEnum = exports.ExportedConstEnum = void 0;
 ;
 var ExportedConstEnum;
 (function (ExportedConstEnum) {
     ExportedConstEnum[ExportedConstEnum["First"] = 0] = "First";
-})(ExportedConstEnum = exports.ExportedConstEnum || (exports.ExportedConstEnum = {}));
+})(ExportedConstEnum || (exports.ExportedConstEnum = ExportedConstEnum = {}));
 var NonExportedEnum;
 (function (NonExportedEnum) {
     NonExportedEnum[NonExportedEnum["First"] = 0] = "First";
@@ -12,8 +13,8 @@ var NonExportedEnum;
 var ExportedEnum;
 (function (ExportedEnum) {
     ExportedEnum[ExportedEnum["First"] = 0] = "First";
-})(ExportedEnum = exports.ExportedEnum || (exports.ExportedEnum = {}));
+})(ExportedEnum || (exports.ExportedEnum = ExportedEnum = {}));
 function doSomething() {
-    console.log(0 /* First */, 0 /* First */, NonExportedEnum.First, ExportedEnum.First);
+    console.log(0 /* NonExportedConstEnum.First */, 0 /* ExportedConstEnum.First */, NonExportedEnum.First, ExportedEnum.First);
 }
 exports.doSomething = doSomething;


### PR DESCRIPTION
Breaking changes within the typescript dependency mean that this transformer is no longer compatible with Typescript v5+.

This PR also updates all the remaining devDependencies to the latest versions. (however this isn't required for upgrading TS to v5)

FYI: `ttypescript` has been deprecated, so we are switching to [ts-patch](https://github.com/nonara/ts-patch) on our project (LWC). Perhaps it would be worth adding a note to `README.md` as well?

I changed the `output.js` file for the test case. The differences appear (to me) to be unrelated to the purpose of the transformer. I've included the various file outputs below so it easier to check if the output is correct.

### Output file contents
#### Typescript v3 without transformer
```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
var NonExportedConstEnum;
(function (NonExportedConstEnum) {
    NonExportedConstEnum[NonExportedConstEnum["First"] = 0] = "First";
})(NonExportedConstEnum || (NonExportedConstEnum = {}));
var ExportedConstEnum;
(function (ExportedConstEnum) {
    ExportedConstEnum[ExportedConstEnum["First"] = 0] = "First";
})(ExportedConstEnum = exports.ExportedConstEnum || (exports.ExportedConstEnum = {}));
var NonExportedEnum;
(function (NonExportedEnum) {
    NonExportedEnum[NonExportedEnum["First"] = 0] = "First";
})(NonExportedEnum || (NonExportedEnum = {}));
var ExportedEnum;
(function (ExportedEnum) {
    ExportedEnum[ExportedEnum["First"] = 0] = "First";
})(ExportedEnum = exports.ExportedEnum || (exports.ExportedEnum = {}));
function doSomething() {
    console.log(0 /* First */, 0 /* First */, NonExportedEnum.First, ExportedEnum.First);
}
exports.doSomething = doSomething;
```
#### Typescript v3 with transformer
```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
;
var ExportedConstEnum;
(function (ExportedConstEnum) {
    ExportedConstEnum[ExportedConstEnum["First"] = 0] = "First";
})(ExportedConstEnum = exports.ExportedConstEnum || (exports.ExportedConstEnum = {}));
var NonExportedEnum;
(function (NonExportedEnum) {
    NonExportedEnum[NonExportedEnum["First"] = 0] = "First";
})(NonExportedEnum || (NonExportedEnum = {}));
var ExportedEnum;
(function (ExportedEnum) {
    ExportedEnum[ExportedEnum["First"] = 0] = "First";
})(ExportedEnum = exports.ExportedEnum || (exports.ExportedEnum = {}));
function doSomething() {
    console.log(0 /* First */, 0 /* First */, NonExportedEnum.First, ExportedEnum.First);
}
exports.doSomething = doSomething;
```
#### Typescript v5 without transformer
```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
exports.doSomething = exports.ExportedEnum = exports.ExportedConstEnum = void 0;
var NonExportedConstEnum;
(function (NonExportedConstEnum) {
    NonExportedConstEnum[NonExportedConstEnum["First"] = 0] = "First";
})(NonExportedConstEnum || (NonExportedConstEnum = {}));
var ExportedConstEnum;
(function (ExportedConstEnum) {
    ExportedConstEnum[ExportedConstEnum["First"] = 0] = "First";
})(ExportedConstEnum || (exports.ExportedConstEnum = ExportedConstEnum = {}));
var NonExportedEnum;
(function (NonExportedEnum) {
    NonExportedEnum[NonExportedEnum["First"] = 0] = "First";
})(NonExportedEnum || (NonExportedEnum = {}));
var ExportedEnum;
(function (ExportedEnum) {
    ExportedEnum[ExportedEnum["First"] = 0] = "First";
})(ExportedEnum || (exports.ExportedEnum = ExportedEnum = {}));
function doSomething() {
    console.log(0 /* NonExportedConstEnum.First */, 0 /* ExportedConstEnum.First */, NonExportedEnum.First, ExportedEnum.First);
}
exports.doSomething = doSomething;
```

#### Typescript v5 with transformer
```js
// Typescript v5 Use transformer
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
exports.doSomething = exports.ExportedEnum = exports.ExportedConstEnum = void 0;
;
var ExportedConstEnum;
(function (ExportedConstEnum) {
    ExportedConstEnum[ExportedConstEnum["First"] = 0] = "First";
})(ExportedConstEnum || (exports.ExportedConstEnum = ExportedConstEnum = {}));
var NonExportedEnum;
(function (NonExportedEnum) {
    NonExportedEnum[NonExportedEnum["First"] = 0] = "First";
})(NonExportedEnum || (NonExportedEnum = {}));
var ExportedEnum;
(function (ExportedEnum) {
    ExportedEnum[ExportedEnum["First"] = 0] = "First";
})(ExportedEnum || (exports.ExportedEnum = ExportedEnum = {}));
function doSomething() {
    console.log(0 /* NonExportedConstEnum.First */, 0 /* ExportedConstEnum.First */, NonExportedEnum.First, ExportedEnum.First);
}
exports.doSomething = doSomething;
```